### PR TITLE
Make "tools" a valid key

### DIFF
--- a/src/alidistlint/headerlint.py
+++ b/src/alidistlint/headerlint.py
@@ -124,6 +124,7 @@ def get_schema_for_file(file_name: str) -> dict:
         'build_requires': requires,
         'env': environment,
         'valid_defaults': {'type': 'list', 'schema': {'type': 'string'}},
+        'tools': {'type': 'list', 'schema': {'type': 'string'}},
         'prepend_path': path_environment,
         'append_path': path_environment,
         'force_rebuild': {'type': 'boolean'},


### PR DESCRIPTION
Make "tools" a valid key

While it's not used by aliBuild itself at the moment, I would like to have at
some point a "tools" section, listing the executables which a given package
builds and which can be used by other steps of the build (e.g. cmake or root).
