### PR TITLE
Fix system_prefer_check comparison

### DIFF
--- a/src/alidistlint/headerlint.py
+++ b/src/alidistlint/headerlint.py
@@ -73,7 +73,7 @@ def get_schema_for_file(file_name: str) -> dict:
             _ = value % {key: 'placeholder' for key in (
                 'branch_basename', 'branch_stream', 'commit_hash',
                 'short_hash', 'tag', 'tag_basename', 'defaults_upper',
-                'year', 'month', 'day', 'hour',
+                'year', 'month', 'day', 'hour', 'key',
             )}
         except KeyError as exc:
             error(field, f'substitution variable {exc} is invalid')
@@ -152,7 +152,7 @@ def get_schema_for_file(file_name: str) -> dict:
             'keysrules': {'type': 'string', 'regex': r'^\S(.*\S)?$'},
             'valuesrules': {
                 'type': 'dict',
-                'schema': {**basic_fields, 'recipe': {'type': 'string'}, 'key': {'type': 'string'}},
+                'schema': {**basic_fields, 'recipe': {'type': 'string'}},
             },
         },
         'system_requirement': {


### PR DESCRIPTION
Fixes the following error:

```
python.sh:60:5: error: prefer_system_replacement_specs.python-brew3.version: substitution variable 'key' is invalid [ali:schema]
```

Also reverts the last attempted fix, as it didn't work properly
