### PR TITLE
Update requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A code linter for alidist packages"
 dynamic = ["version"]
 readme = "README.md"
 # We need __future__.annotations (3.7+).
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
It doesn't actually run in 3.7

```bash
$ python3.8 alidistlint >/dev/null root.sh                                            0.19s
Traceback (most recent call last):
  File "/Users/sergio/.cache/uv/archive-v0/v7fTvvh4DiydfFItL7P4S/bin/alidistlint", line 6, in <module>
    from alidistlint.run import main
  File "/Users/sergio/.cache/uv/archive-v0/v7fTvvh4DiydfFItL7P4S/lib/python3.8/site-packages/alidistlint/run.py", line 11, in <module>
    from alidistlint.headerlint import headerlint
  File "/Users/sergio/.cache/uv/archive-v0/v7fTvvh4DiydfFItL7P4S/lib/python3.8/site-packages/alidistlint/headerlint.py", line 12, in <module>
    ValidationErrors = list[Union[str, dict[Any, 'ValidationErrors']]]
TypeError: 'type' object is not subscriptabl
```
