### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 name: Publish release
 
 'on':
+  workflow_dispatch:
   push:
     tags:
       - 'v**'
@@ -9,31 +10,23 @@ name: Publish release
     types:
       - published
 
-permissions: {}
-
 jobs:
-  pypi:
-    name: PyPI
+  pypi-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/alidistlint
     permissions:
-      contents: read
-      id-token: write  # for PyPA OIDC auth
-
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - name: Install prerequisites
-        run: python3 -m pip install --user build twine
+    # retrieve your distributions here
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+    - name: Build package distributions
+      run: |
+        uv build --python 3.11 
 
-      - name: Checkout tag
-        uses: actions/checkout@v3
-
-      - name: Build release distributions
-        run: python3 -m build -o dist
-
-      # Make sure the wheel and source dist we've just built are valid.
-      # pypa/gh-action-pypi-publish checks this, but recommends we do too.
-      - name: Check distributions are valid
-        run: python3 -m twine check dist/*
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
There is some issue with the `twine` version in the action. Also adding a workflow_run: to make it easier to rerun/debug in the future

I'm also trying out https://astral.sh/uv here as it's lower stakes. I want to eventually handle the python from the daily builds using this to get rid of all the `venv` magic there 